### PR TITLE
Filter dashboard inference and evaluation for partial datasets

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -1,4 +1,5 @@
 import os
+from typing import List, Optional, Set
 
 import pandas as pd
 from dotenv import load_dotenv
@@ -17,9 +18,47 @@ from utils import (
 import os
 
 logger = setup_logger(__name__)
+def _filter_by_metadata(df: pd.DataFrame,
+                        types: Optional[List[str]] = None,
+                        levels: Optional[List[str]] = None,
+                        tags: Optional[List[str]] = None) -> pd.DataFrame:
+    if df.empty:
+        return df
+    mask = pd.Series([True] * len(df))
+    if types:
+        mask &= df["questionMetadata"].apply(lambda m: m.get("type") in set(types))
+    if levels:
+        mask &= df["questionMetadata"].apply(lambda m: m.get("level") in set(levels))
+    if tags:
+        mask &= df["questionMetadata"].apply(lambda m: m.get("tag") in set(tags))
+    return df[mask]
 
 
-def main(task: str, prompt_name: str, evaluatee_model: str, evaluator_model: str):
+def _load_existing_eval_ids(output_path: str) -> Set[str]:
+    if not os.path.exists(output_path):
+        return set()
+    try:
+        existing = pd.read_json(output_path, lines=True)
+        if "questionId" not in existing.columns:
+            return set()
+        # Consider evaluated if acceptabilityScore present (any type) and not NaN
+        if "acceptabilityScore" in existing.columns:
+            has_score = existing["acceptabilityScore"].notna()
+            return set(existing.loc[has_score, "questionId"].astype(str).tolist())
+        return set(existing["questionId"].astype(str).tolist())
+    except Exception as e:
+        logger.warning(f"Failed to read existing evaluation file {output_path}: {e}")
+        return set()
+
+
+def main(task: str,
+         prompt_name: str,
+         evaluatee_model: str,
+         evaluator_model: str,
+         types: Optional[List[str]] = None,
+         levels: Optional[List[str]] = None,
+         tags: Optional[List[str]] = None,
+         skip_existing: bool = True):
     prompt = PROMPTS[prompt_name]
     input_path = f"output/{task}/inf/{evaluatee_model}.jsonl"
     if not os.path.exists(input_path):
@@ -27,9 +66,26 @@ def main(task: str, prompt_name: str, evaluatee_model: str, evaluator_model: str
             f"Inference for {evaluatee_model} has not been run on task {task}."
         )
 
-    evaluatee_data = pd.read_json(input_path, lines=True)
-    messages = batch_format_prompt(PROMPTS[prompt_name], evaluatee_data)
-    logger.info("Loaded %s messages for inference on task %s.", len(messages), task)
+    evaluatee_all = pd.read_json(input_path, lines=True)
+    evaluatee_data = _filter_by_metadata(evaluatee_all, types=types, levels=levels, tags=tags).reset_index(drop=True)
+    if evaluatee_data.empty:
+        logger.info("No tasks match the provided filters. Nothing to evaluate.")
+        return
+
+    output_path = f"output/{task}/evl/{evaluator_model}/{prompt_name}/{evaluatee_model}.jsonl"
+    selected_ids: Set[str] = set(evaluatee_data["questionId"].astype(str).tolist())
+    already_evaluated_ids: Set[str] = _load_existing_eval_ids(output_path) if skip_existing else set()
+    to_run_ids = list(selected_ids - already_evaluated_ids)
+
+    if skip_existing and len(to_run_ids) == 0:
+        logger.info("All %d selected tasks already evaluated by %s for %s. Skipping.", len(selected_ids), evaluator_model, prompt_name)
+        return
+
+    run_df = evaluatee_data[evaluatee_data["questionId"].astype(str).isin(to_run_ids)] if to_run_ids else evaluatee_data
+
+    messages = batch_format_prompt(PROMPTS[prompt_name], run_df)
+    logger.info("Loaded %s messages for evaluation on task %s (selected=%d, remaining=%d).",
+                len(messages), task, len(selected_ids), len(run_df))
 
     if evaluator_model not in LLMS:
         raise ValueError(f"Model {evaluator_model} not found in the configuration.")
@@ -50,11 +106,19 @@ def main(task: str, prompt_name: str, evaluatee_model: str, evaluator_model: str
     if empty_evaluations > 0:
         logger.warning("Empty evaluations found: %s.", empty_evaluations)
         parsed_completions_df = _fillna(parsed_completions_df)
-    evaluatee_data = pd.concat([evaluatee_data, parsed_completions_df], axis=1)
+    run_df = pd.concat([run_df, parsed_completions_df], axis=1)
 
-    output_path = f"output/{task}/evl/{evaluator_model}/{prompt_name}/{evaluatee_model}.jsonl"
     os.makedirs(os.path.dirname(output_path), exist_ok=True)
-    evaluatee_data.to_json(output_path, lines=True, orient="records")
+    if os.path.exists(output_path):
+        try:
+            existing = pd.read_json(output_path, lines=True)
+        except Exception:
+            existing = pd.DataFrame()
+        combined = pd.concat([existing, run_df], ignore_index=True)
+        combined = combined.drop_duplicates(subset=["questionId"], keep="last")
+        combined.to_json(output_path, lines=True, orient="records")
+    else:
+        run_df.to_json(output_path, lines=True, orient="records")
 
     logger.info("Saved evaluations to %s", output_path)
 
@@ -77,7 +141,20 @@ if __name__ == "__main__":
     parser.add_argument("--prompt", "-p", default="eval-cot-ref", type=str, choices=[p for p in PROMPTS.keys() if p.startswith("eval")], help="The prompt to use for evaluation.")
     parser.add_argument("--evaluatee", "-e", required=True, type=str, choices=LLMS.keys(), help="The model whose output will be evaluated.")
     parser.add_argument("--evaluator", "-j", default="gpt-4-turbo-2024-04-09", type=str, choices=LLMS.keys(), help="The model to use for evaluation.")
+    parser.add_argument("--types", "-T", nargs="*", default=None, help="Optional list of task types to include (space-separated).")
+    parser.add_argument("--levels", "-L", nargs="*", default=None, help="Optional list of task levels to include (space-separated).")
+    parser.add_argument("--tags", "-G", nargs="*", default=None, help="Optional list of programming language tags to include (space-separated).")
+    parser.add_argument("--no-skip-existing", action="store_true", help="Do not skip tasks already evaluated; re-run them.")
     args = parser.parse_args()
     #fmt: on
 
-    main(args.task, args.prompt, args.evaluatee, args.evaluator)
+    main(
+        args.task,
+        args.prompt,
+        args.evaluatee,
+        args.evaluator,
+        types=args.types,
+        levels=args.levels,
+        tags=args.tags,
+        skip_existing=not args.no_skip_existing,
+    )

--- a/inference.py
+++ b/inference.py
@@ -1,4 +1,5 @@
 import os
+from typing import List, Optional, Set
 
 import pandas as pd
 from dotenv import load_dotenv
@@ -10,35 +11,109 @@ import os
 
 logger = setup_logger(__name__)
 
+def _filter_by_metadata(df: pd.DataFrame,
+                        types: Optional[List[str]] = None,
+                        levels: Optional[List[str]] = None,
+                        tags: Optional[List[str]] = None) -> pd.DataFrame:
+    """
+    Filter a raw tasks dataframe (with questionMetadata column) by optional
+    type/level/tag lists. If a list is empty/None, that dimension is not filtered.
+    """
+    if df.empty:
+        return df
+    mask = pd.Series([True] * len(df))
+    if types:
+        mask &= df["questionMetadata"].apply(lambda m: m.get("type") in set(types))
+    if levels:
+        mask &= df["questionMetadata"].apply(lambda m: m.get("level") in set(levels))
+    if tags:
+        mask &= df["questionMetadata"].apply(lambda m: m.get("tag") in set(tags))
+    return df[mask]
 
-def main(task: str, model_name: str):
-    data = pd.read_json(TASKS[task], lines=True)
-    prompt = PROMPTS["stack-inf"]
-    messages = batch_format_prompt(prompt, data)
-    logger.info("Loaded %s messages for inference on task %s.", len(messages), task)
+
+def _load_existing_inference_ids(output_path: str) -> Set[str]:
+    if not os.path.exists(output_path):
+        return set()
+    try:
+        existing = pd.read_json(output_path, lines=True)
+        if "questionId" not in existing.columns:
+            return set()
+        # Consider a task solved if completion is a non-empty string
+        solved = existing[existing.get("completion", "").astype(str).str.len() > 0]
+        return set(solved["questionId"].astype(str).tolist())
+    except Exception as e:
+        logger.warning(f"Failed to read existing inference file {output_path}: {e}")
+        return set()
+
+
+def main(task: str,
+         model_name: str,
+         types: Optional[List[str]] = None,
+         levels: Optional[List[str]] = None,
+         tags: Optional[List[str]] = None,
+         skip_existing: bool = True):
+    """
+    Run inference for the specified dataset/model. Optionally restrict to a subset
+    of tasks by type/level/tag, and skip tasks already solved in the output file.
+    """
+    raw = pd.read_json(TASKS[task], lines=True)
+    data = _filter_by_metadata(raw, types=types, levels=levels, tags=tags).reset_index(drop=True)
+    if data.empty:
+        logger.info("No tasks match the provided filters. Nothing to do.")
+        return
 
     if model_name not in LLMS:
         raise ValueError(f"Model {model_name} not found in the configuration.")
     model = LLMS[model_name]
-    logger.info("Launching batch completion using model %s...", model_name)
 
+    output_path = f"output/{task}/inf/{model_name}.jsonl"
+
+    # Optionally skip tasks already solved
+    already_solved_ids: Set[str] = _load_existing_inference_ids(output_path) if skip_existing else set()
+    subset_ids: Set[str] = set(data["questionId"].astype(str).tolist())
+    to_run_ids = list(subset_ids - already_solved_ids)
+
+    if skip_existing and len(to_run_ids) == 0:
+        logger.info("All %d selected tasks already have completions for %s. Skipping.", len(subset_ids), model_name)
+        return
+
+    run_df = data[data["questionId"].astype(str).isin(to_run_ids)] if to_run_ids else data
+
+    prompt = PROMPTS["stack-inf"]
+    messages = batch_format_prompt(prompt, run_df)
+    logger.info("Loaded %s messages for inference on task %s (selected=%d, remaining=%d).",
+                len(messages), task, len(subset_ids), len(run_df))
+
+    logger.info("Launching batch completion using model %s...", model_name)
     # Allow override timeout via env
     request_timeout = float(os.getenv("LLM_REQUEST_TIMEOUT", "120"))
-    data["completion"] = completion(
+    completions = completion(
         messages,
         custom_llm_provider=model['custom_llm_provider'],
         **model['model_parameters'], **model['sample_parameters'],
         num_retries=3, timeout=request_timeout
     )
-    empty_completions = (data["completion"].str.len() == 0).sum()
+    run_df = run_df.copy()
+    run_df["completion"] = completions
+    empty_completions = (pd.Series(completions).astype(str).str.len() == 0).sum()
     if empty_completions > 0:
         logger.warning("Found %s empty completions.", empty_completions)
-    data["model"] = [model["model_parameters"]["model"] for _ in range(len(data))]
-    data["modelMetadata"] = [model["model_metadata"] for _ in range(len(data))]
+    run_df["model"] = [model["model_parameters"]["model"] for _ in range(len(run_df))]
+    run_df["modelMetadata"] = [model["model_metadata"] for _ in range(len(run_df))]
 
-    output_path = f"output/{task}/inf/{model_name}.jsonl"
+    # Merge with any existing outputs (keep previous rows for other IDs)
     os.makedirs(os.path.dirname(output_path), exist_ok=True)
-    data.to_json(output_path, lines=True, orient="records")
+    if os.path.exists(output_path):
+        try:
+            existing = pd.read_json(output_path, lines=True)
+        except Exception:
+            existing = pd.DataFrame()
+        combined = pd.concat([existing, run_df], ignore_index=True)
+        # De-duplicate on questionId, prefer latest results
+        combined = combined.drop_duplicates(subset=["questionId"], keep="last")
+        combined.to_json(output_path, lines=True, orient="records")
+    else:
+        run_df.to_json(output_path, lines=True, orient="records")
     logger.info("Saved completions to %s", output_path)
 
 
@@ -48,8 +123,19 @@ if __name__ == "__main__":
     #fmt: off
     parser = argparse.ArgumentParser(description="Run inference on a task using a specified model.")
     parser.add_argument("--task", "-t", required=True, type=str, choices=TASKS.keys(), help="The task to run inference on.")
-    parser.add_argument( "--model", "-m", required=True, type=str, choices=LLMS.keys(), help="The model to use for inference.")
+    parser.add_argument("--model", "-m", required=True, type=str, choices=LLMS.keys(), help="The model to use for inference.")
+    parser.add_argument("--types", "-T", nargs="*", default=None, help="Optional list of task types to include (space-separated).")
+    parser.add_argument("--levels", "-L", nargs="*", default=None, help="Optional list of task levels to include (space-separated).")
+    parser.add_argument("--tags", "-G", nargs="*", default=None, help="Optional list of programming language tags to include (space-separated).")
+    parser.add_argument("--no-skip-existing", action="store_true", help="Do not skip tasks that already have completions; re-generate.")
     args = parser.parse_args()
     #fmt: on
 
-    main(args.task, args.model)
+    main(
+        args.task,
+        args.model,
+        types=args.types,
+        levels=args.levels,
+        tags=args.tags,
+        skip_existing=not args.no_skip_existing,
+    )


### PR DESCRIPTION
Enable partial dataset inference in `inference.py` with task metadata filters and skip-existing logic to reduce runtimes for users interested in specific task subsets.

---
<a href="https://cursor.com/background-agent?bcId=bc-0d1738a8-acc3-4687-b1d7-246dcb73822b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0d1738a8-acc3-4687-b1d7-246dcb73822b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

